### PR TITLE
Trigger the collection height resize when the component is activated.

### DIFF
--- a/src/vue-collection-cluster.vue
+++ b/src/vue-collection-cluster.vue
@@ -123,6 +123,9 @@ export default {
 			window.removeEventListener('resize', this.onResize);
 		}
 	},
+	activated() {
+		this.onResize();
+	},
 	methods: {
 		onScroll(event) {
 			this.scrollTop = this.$el.scrollTop;


### PR DESCRIPTION
Height clipping occurs when the collection cluster is loaded and toggled using dynamic components, or the collection cluster is hidden with v-show, and then resized.

To reproduce: 
Load one or more collection clusters. Hide them from view, either by toggling v-show or using a <keepalive> dynamic component and a switching between A and B. If the window is resized while A is shown, B will exhibit clipping behaviour, and vice versa. Since mounting doesn't occur again, the collection height falls out of sync with the window.

To fix: 
Reassessing the collection height using onResize when the component is reactivated ensures the collection height is correct, and no clipping occurs.